### PR TITLE
Update to 1.6.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gst-plugins-bad-1.4.5.tar.xz
 gst-plugins-bad-1.6.1.tar.xz
 gst-plugins-bad-1.6.2.tar.xz
 gst-plugins-bad-1.6.3.tar.xz
+gst-plugins-bad-1.6.4.tar.xz

--- a/gstreamer1-plugins-bad-freeworld.spec
+++ b/gstreamer1-plugins-bad-freeworld.spec
@@ -4,7 +4,7 @@
 
 Summary:        GStreamer 1.0 streaming media framework "bad" plug-ins
 Name:           gstreamer1-plugins-bad-freeworld
-Version:        1.6.3
+Version:        1.6.4
 Release:        1%{?dist}
 License:        LGPLv2+
 Group:          Applications/Multimedia
@@ -72,7 +72,8 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/*.la
 
 
 %files
-%doc AUTHORS COPYING.LIB NEWS README RELEASE
+%doc AUTHORS NEWS README RELEASE
+%license COPYING.LIB
 # Take the whole dir for proper dir ownership (shared with other plugin pkgs)
 %{_datadir}/gstreamer-1.0
 
@@ -96,6 +97,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/*.la
 
 
 %changelog
+* Sat May 21 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.6.4-1
+- Update to 1.6.4
+
 * Sat Jan 23 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.6.3-1
 - Rebase to new upstream release 1.6.3
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-4857adcafe41e4b9b8805cf88303bd55  gst-plugins-bad-1.6.3.tar.xz
+6768524cb8bcdcaf1345d9c66f3bd7bd  gst-plugins-bad-1.6.4.tar.xz


### PR DESCRIPTION
Update rpmfusion gstreamer1-\* f23 packages to 1.6.4, to bring them in sync with their Fedora counterparts.

tarbals have been uploaded to the look-a-side cache already.
