### PR TITLE
Rebase to new upstream release 1.8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ gst-plugins-bad-1.6.1.tar.xz
 gst-plugins-bad-1.6.2.tar.xz
 gst-plugins-bad-1.6.3.tar.xz
 gst-plugins-bad-1.8.1.tar.xz
+gst-plugins-bad-1.8.2.tar.xz

--- a/gstreamer1-plugins-bad-freeworld.spec
+++ b/gstreamer1-plugins-bad-freeworld.spec
@@ -4,7 +4,7 @@
 
 Summary:        GStreamer 1.0 streaming media framework "bad" plug-ins
 Name:           gstreamer1-plugins-bad-freeworld
-Version:        1.8.1
+Version:        1.8.2
 Release:        1%{?dist}
 License:        LGPLv2+
 Group:          Applications/Multimedia
@@ -39,9 +39,6 @@ well enough, or the code is not of good enough quality.
 
 %prep
 %setup -q -n gst-plugins-bad-%{version}
-# hack to allow building against 1.6.0 as 1.6.3 is not yet in the buildroot
-sed -i 's/GST_REQ=1.6.3/GST_REQ=1.6.0/' configure
-sed -i 's/GSTPB_REQ=1.6.3/GSTPB_REQ=1.6.0/' configure
 
 
 %build
@@ -95,6 +92,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/*.la
 
 
 %changelog
+* Sun Jun 12 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.8.2-1
+- Rebase to new upstream release 1.8.2
+
 * Wed May 18 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.8.1-1
 - Rebase to new upstream release 1.8.1
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-e508da2a8a5c3d12264fe3415be2f451  gst-plugins-bad-1.8.1.tar.xz
+83abc2e70684e7b195f18ca2992ef6e8  gst-plugins-bad-1.8.2.tar.xz


### PR DESCRIPTION
Update rpmfusion gstreamer pkgs to 1.8.2, to bring them in sync with F24, tarballs have already been uploaded to the (old) look-a-side cache.
